### PR TITLE
macOS fix for commit #394741

### DIFF
--- a/src/tzdb/CMakeLists.txt
+++ b/src/tzdb/CMakeLists.txt
@@ -24,9 +24,15 @@ execute_process(
 
 string(REPLACE "\n" "" TZ_COMMIT_TIME "${TZ_COMMIT_TIME}")
 
+if (APPLE)
+	set(VERSION_COMMAND ${GNU_DATE} -r ${TZ_COMMIT_TIME} +%y%m%d) 
+else ()
+	set(VERSION_COMMAND ${GNU_DATE} +%y%m%d --date=@${TZ_COMMIT_TIME})
+endif ()
+
 execute_process(
     COMMAND
-        ${GNU_DATE} +%y%m%d --date=@${TZ_COMMIT_TIME}
+		${VERSION_COMMAND}
     OUTPUT_VARIABLE
         TZDB_VERSION
     COMMAND_ERROR_IS_FATAL ANY)


### PR DESCRIPTION
Fix for commit #394741, which broke macOS building because the macOS date takes slightly different arguments