### PR TITLE
workflows: Build x80e target

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target x80e
       
     - name: Package
       run: |


### PR DESCRIPTION
x80e was removed from the `all` target and was no longer building. Workflows should be specifying what target to build, anyway.