### PR TITLE
CMake: Find and require intl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,9 @@ project(tzdb2nx VERSION 1.0)
 
 set(CMAKE_CXX_STANDARD 20)
 
+if (APPLE)
+    find_package(Intl REQUIRED)
+endif()
+
 add_subdirectory(externals)
 add_subdirectory(src)

--- a/externals/tz/CMakeLists.txt
+++ b/externals/tz/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT EXISTS "${TZ_DIR}" OR NOT EXISTS "${TZIF_LIST_FILE}")
     file(COPY ${TZ_SOURCE_DIR}/ DESTINATION ${TZ_TMP_SOURCE_DIR})
 
     if (APPLE)
-        set(TZ_MAKEFLAGS "LDLIBS=-lintl")
+        set(TZ_MAKEFLAGS "LDLIBS=${Intl_LIBRARY}")
     else()
         set(TZ_MAKEFLAGS)
     endif()


### PR DESCRIPTION
It's not guaranteed for Apple systems to have this library installed, apparently, so check for it.