### PR TITLE
cmake: Add option to specify custom zoneinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ cmake_minimum_required(VERSION 3.10)
 project(tzdb2nx VERSION 1.0)
 
 option(TZDB2NX_ZONEINFO_DIR "Specify a custom zoneinfo directory containing time zone data you wish to use" "")
+option(TZDB2NX_VERSION "Specify a custom zoneinfo version with the directory" "")
+
+if ((TZDB2NX_ZONEINFO_DIR AND NOT TZDB2NX_VERSION) OR (TZDB2NX_VERSION AND NOT TZDB2NX_ZONEINFO_DIR))
+    message(FATAL_ERROR "Either TZDB2NX_ZONEINFO_DIR or TZDB2NX_VERSION but not both were defined.")
+endif()
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(tzdb2nx VERSION 1.0)
 
+option(TZDB2NX_ZONEINFO_DIR "Specify a custom zoneinfo directory containing time zone data you wish to use" "")
+
 set(CMAKE_CXX_STANDARD 20)
 
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ project(tzdb2nx VERSION 1.0)
 option(TZDB2NX_ZONEINFO_DIR "Specify a custom zoneinfo directory containing time zone data you wish to use" "")
 option(TZDB2NX_VERSION "Specify a custom zoneinfo version with the directory" "")
 
-if ((TZDB2NX_ZONEINFO_DIR AND NOT TZDB2NX_VERSION) OR (TZDB2NX_VERSION AND NOT TZDB2NX_ZONEINFO_DIR))
-    message(FATAL_ERROR "Either TZDB2NX_ZONEINFO_DIR or TZDB2NX_VERSION but not both were defined.")
+if (TZDB2NX_ZONEINFO_DIR AND NOT TZDB2NX_VERSION)
+    message(FATAL_ERROR "TZDB2NX_ZONEINFO_DIR was specified but TZDB2NX_VERSION was left undefined.")
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/externals/tz/CMakeLists.txt
+++ b/externals/tz/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT GIT_PROGRAM)
 endif()
 
 if (NOT EXISTS "${TZ_DIR}" OR NOT EXISTS "${TZIF_LIST_FILE}")
-    if (NOT TZDB2NX_ZONEINFO_DIR)
+    if (NOT TZDB2NX_ZONEINFO_DIR) # If a custom zoneinfo directory was specified
         # tz's makefile can only build in-tree, so copy the whole source tree to a
         # separate directory before building.
         execute_process(

--- a/externals/tz/CMakeLists.txt
+++ b/externals/tz/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TZ_ZONEINFO_DIR "${TZ_DIR}/usr/share/zoneinfo" CACHE PATH "Time zone info da
 set(TZIF_LIST_FILE "${CMAKE_CURRENT_BINARY_DIR}/tzif_list.txt" CACHE PATH "List of zone info files")
 
 find_program(GNU_MAKE make)
-if ("${GNU_MAKE}" STREQUAL "GNU_MAKE-NOTFOUND")
+if (NOT GNU_MAKE)
     message(FATAL_ERROR "GNU make not found")
 endif()
 

--- a/externals/tz/CMakeLists.txt
+++ b/externals/tz/CMakeLists.txt
@@ -12,7 +12,11 @@ endif()
 if (NOT EXISTS "${TZ_DIR}" OR NOT EXISTS "${TZIF_LIST_FILE}")
     # tz's makefile can only build in-tree, so copy the whole source tree to a
     # separate directory before building.
-    file(COPY ${TZ_SOURCE_DIR}/ DESTINATION ${TZ_TMP_SOURCE_DIR})
+    execute_process(
+        COMMAND
+            ${GIT_PROGRAM} clone --depth 1 "file://${TZ_SOURCE_DIR}" "${TZ_TMP_SOURCE_DIR}"
+        COMMAND_ERROR_IS_FATAL ANY
+    )
 
     if (APPLE)
         set(TZ_MAKEFLAGS "LDLIBS=${Intl_LIBRARY}")

--- a/externals/tz/CMakeLists.txt
+++ b/externals/tz/CMakeLists.txt
@@ -1,47 +1,58 @@
 set(TZ_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tz" CACHE PATH "Time zone source directory")
 set(TZ_DIR "${CMAKE_CURRENT_BINARY_DIR}/tz")
 set(TZ_TMP_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/tmpsrc")
-set(TZ_ZONEINFO_DIR "${TZ_DIR}/usr/share/zoneinfo" CACHE PATH "Time zone info data directory")
 set(TZIF_LIST_FILE "${CMAKE_CURRENT_BINARY_DIR}/tzif_list.txt" CACHE PATH "List of zone info files")
+if (TZDB2NX_ZONEINFO_DIR)
+    set(TZ_ZONEINFO_DIR "${TZDB2NX_ZONEINFO_DIR}" CACHE PATH "Time zone info data directory")
+else()
+    set(TZ_ZONEINFO_DIR "${TZ_DIR}/usr/share/zoneinfo" CACHE PATH "Time zone info data directory")
+endif()
 
 find_program(GNU_MAKE make)
 if (NOT GNU_MAKE)
     message(FATAL_ERROR "GNU make not found")
 endif()
 
+find_program(GIT_PROGRAM git)
+if (NOT GIT_PROGRAM)
+    message(FATAL_ERROR "git program not found")
+endif()
+
 if (NOT EXISTS "${TZ_DIR}" OR NOT EXISTS "${TZIF_LIST_FILE}")
-    # tz's makefile can only build in-tree, so copy the whole source tree to a
-    # separate directory before building.
-    execute_process(
-        COMMAND
-            ${GIT_PROGRAM} clone --depth 1 "file://${TZ_SOURCE_DIR}" "${TZ_TMP_SOURCE_DIR}"
-        COMMAND_ERROR_IS_FATAL ANY
-    )
+    if (NOT TZDB2NX_ZONEINFO_DIR)
+        # tz's makefile can only build in-tree, so copy the whole source tree to a
+        # separate directory before building.
+        execute_process(
+            COMMAND
+                ${GIT_PROGRAM} clone --depth 1 "file://${TZ_SOURCE_DIR}" "${TZ_TMP_SOURCE_DIR}"
+            COMMAND_ERROR_IS_FATAL ANY
+        )
 
-    if (APPLE)
-        set(TZ_MAKEFLAGS "LDLIBS=${Intl_LIBRARY}")
-    else()
-        set(TZ_MAKEFLAGS)
+        if (APPLE)
+            set(TZ_MAKEFLAGS "LDLIBS=${Intl_LIBRARY}")
+        else()
+            set(TZ_MAKEFLAGS)
+        endif()
+
+        execute_process(
+            COMMAND
+                ${GNU_MAKE} DESTDIR=${TZ_DIR} ${TZ_MAKEFLAGS} install
+            WORKING_DIRECTORY 
+                ${TZ_TMP_SOURCE_DIR}
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+
+        unset(TZ_MAKEFLAGS)
+
+        # Step taken by Arch Linux packaging, but Nintendo apparently skips it
+        # execute_process(
+        #     COMMAND
+        #         "${TZDB_LOCATION}/zic" -b fat -d ${TZDB_ZONEINFO} africa antarctica asia australasia europe northamerica southamerica etcetera backward factory
+        #     WORKING_DIRECTORY
+        #         "${TZDB_LOCATION}"
+        #     COMMAND_ERROR_IS_FATAL ANY
+        # )
     endif()
-
-    execute_process(
-        COMMAND
-            ${GNU_MAKE} DESTDIR=${TZ_DIR} ${TZ_MAKEFLAGS} install
-        WORKING_DIRECTORY 
-            ${TZ_TMP_SOURCE_DIR}
-        COMMAND_ERROR_IS_FATAL ANY
-    )
-
-    unset(TZ_MAKEFLAGS)
-
-    # Step taken by Arch Linux packaging, but Nintendo apparently skips it
-    # execute_process(
-    #     COMMAND
-    #         "${TZDB_LOCATION}/zic" -b fat -d ${TZDB_ZONEINFO} africa antarctica asia australasia europe northamerica southamerica etcetera backward factory
-    #     WORKING_DIRECTORY
-    #         "${TZDB_LOCATION}"
-    #     COMMAND_ERROR_IS_FATAL ANY
-    # )
 
     execute_process(
         COMMAND

--- a/src/tzdb/CMakeLists.txt
+++ b/src/tzdb/CMakeLists.txt
@@ -1,10 +1,10 @@
 find_program(GIT_PROGRAM git)
-if ("${GIT_PROGRAM}" STREQUAL "GIT_PROGRAM-NOTFOUND")
+if (NOT GIT_PROGRAM)
     message(FATAL_ERROR "git program not found")
 endif()
 
 find_program(GNU_DATE date)
-if ("${GNU_DATE}" STREQUAL "GNU_DATE-NOTFOUND")
+if (NOT GNU_DATE)
     message(FATAL_ERROR "date program not found")
 endif()
 

--- a/src/tzdb/CMakeLists.txt
+++ b/src/tzdb/CMakeLists.txt
@@ -13,29 +13,33 @@ set(NX_ZONEINFO_DIR "${NX_TZDB_DIR}/zoneinfo")
 
 set(TZDB_VERSION_FILE ${TZ_SOURCE_DIR}/NEWS)
 
-execute_process(
-    COMMAND 
-        ${GIT_PROGRAM} log --pretty=%at -n1 NEWS
-    OUTPUT_VARIABLE
-        TZ_COMMIT_TIME
-    WORKING_DIRECTORY
-        ${TZ_SOURCE_DIR}
-    COMMAND_ERROR_IS_FATAL ANY)
+if (NOT "${TZDB2NX_VERSION}" STREQUAL "")
+    set(TZDB_VERSION "${TZDB2NX_VERSION}\n")
+else()
+    execute_process(
+        COMMAND 
+            ${GIT_PROGRAM} log --pretty=%at -n1 NEWS
+        OUTPUT_VARIABLE
+            TZ_COMMIT_TIME
+        WORKING_DIRECTORY
+            ${TZ_SOURCE_DIR}
+        COMMAND_ERROR_IS_FATAL ANY)
 
-string(REPLACE "\n" "" TZ_COMMIT_TIME "${TZ_COMMIT_TIME}")
+    string(REPLACE "\n" "" TZ_COMMIT_TIME "${TZ_COMMIT_TIME}")
 
-if (APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
-	set(VERSION_COMMAND ${GNU_DATE} -r ${TZ_COMMIT_TIME} +%y%m%d) 
-else ()
-	set(VERSION_COMMAND ${GNU_DATE} +%y%m%d --date=@${TZ_COMMIT_TIME})
-endif ()
+    if (APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
+        set(VERSION_COMMAND ${GNU_DATE} -r ${TZ_COMMIT_TIME} +%y%m%d)
+    else ()
+        set(VERSION_COMMAND ${GNU_DATE} +%y%m%d --date=@${TZ_COMMIT_TIME})
+    endif ()
 
-execute_process(
-    COMMAND
-		${VERSION_COMMAND}
-    OUTPUT_VARIABLE
-        TZDB_VERSION
-    COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(
+        COMMAND
+            ${VERSION_COMMAND}
+        OUTPUT_VARIABLE
+            TZDB_VERSION
+        COMMAND_ERROR_IS_FATAL ANY)
+endif()
 
 set(NX_VERSION_FILE ${NX_TZDB_DIR}/version.txt)
 file(WRITE ${NX_VERSION_FILE} "${TZDB_VERSION}")


### PR DESCRIPTION
Enables developers to use a different zoneinfo source than the included submodule by specifying the option `TZDB2NX_ZONEINFO_DIR`.

Also a couple of small fixes.

Closes #16 
@tachi107 please check if this is what you were asking for.
