### PR TITLE
main: Resolve memory leak

### DIFF
--- a/src/tzdb2nx/main.cpp
+++ b/src/tzdb2nx/main.cpp
@@ -122,6 +122,8 @@ int main(int argc, char *argv[]) {
     return -1;
   }
 
+  delete[] buf;
+
   std::vector<u_int8_t> output_buffer;
   tzif_data->ReformatNintendo(output_buffer);
 


### PR DESCRIPTION
I forgot to free the file buffer once I was done with it.

Delete it and avoid a memory leak.